### PR TITLE
Preview mode

### DIFF
--- a/pages/[id].tsx
+++ b/pages/[id].tsx
@@ -72,7 +72,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
   }
 };
 
-export const getStaticProps: GetStaticProps = async ({ params }) => {
+export const getStaticProps: GetStaticProps = async ({ params, preview }) => {
   if (!(typeof params?.id === 'string')) {
     return {
       props: {
@@ -81,7 +81,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     };
   }
 
-  const pageProps = await getPageProps(params.id);
+  const pageProps = await getPageProps(params.id, preview);
 
   return {
     props: pageProps,

--- a/pages/api/preview.ts
+++ b/pages/api/preview.ts
@@ -1,0 +1,36 @@
+import { Directus } from '@directus/sdk';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+const preview = async (req: NextApiRequest, res: NextApiResponse) => {
+  // Check the token and next parameters
+  // This token should only be known to this API route and the CMS
+  if (
+    req.query.token !== process.env.PREVIEW_TOKEN ||
+    typeof req.query.slug !== 'string'
+  ) {
+    return res.status(401).json({ message: 'Invalid token' });
+  }
+
+  const slug = req.query.slug !== '/' ? req.query.slug : 'start';
+
+  // Fetch the headless CMS to check if the provided `slug` exists
+  const directus = new Directus(process.env.DIRECTUS || '');
+
+  const page = await directus.items('pages').readOne(slug, {
+    fields: ['slug'],
+  });
+
+  // If the slug doesn't exist prevent preview mode from being enabled
+  if (!page) {
+    return res.status(401).json({ message: 'Invalid slug' });
+  }
+
+  // Enable Preview Mode by setting the cookies
+  res.setPreviewData({});
+
+  // Redirect to the path from the fetched page
+  // We don't redirect to req.query.slug as that might lead to open redirect vulnerabilities
+  res.redirect(page.slug);
+};
+
+export default preview;

--- a/pages/api/preview.ts
+++ b/pages/api/preview.ts
@@ -30,7 +30,7 @@ const preview = async (req: NextApiRequest, res: NextApiResponse) => {
 
   // Redirect to the path from the fetched page
   // We don't redirect to req.query.slug as that might lead to open redirect vulnerabilities
-  res.redirect(page.slug);
+  res.redirect(`/${page.slug}`);
 };
 
 export default preview;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -29,8 +29,8 @@ const Start = ({ page }: PageProps): ReactElement => {
   );
 };
 
-export const getStaticProps: GetStaticProps = async () => {
-  const pageProps = await getPageProps('start');
+export const getStaticProps: GetStaticProps = async ({ preview }) => {
+  const pageProps = await getPageProps('start', preview);
 
   return {
     props: pageProps,

--- a/pages/orte/[slug].tsx
+++ b/pages/orte/[slug].tsx
@@ -80,7 +80,7 @@ const MunicipalityPage = ({ page, municipality }: PageProps): ReactElement => {
 export const getServerSideProps: GetServerSideProps = async ({
   params,
   res,
-  preview
+  preview,
 }) => {
   res.setHeader(
     'Cache-Control',

--- a/pages/orte/[slug].tsx
+++ b/pages/orte/[slug].tsx
@@ -80,6 +80,7 @@ const MunicipalityPage = ({ page, municipality }: PageProps): ReactElement => {
 export const getServerSideProps: GetServerSideProps = async ({
   params,
   res,
+  preview
 }) => {
   res.setHeader(
     'Cache-Control',
@@ -104,7 +105,7 @@ export const getServerSideProps: GetServerSideProps = async ({
     };
   }
 
-  const pageProps = await getPageProps('orte');
+  const pageProps = await getPageProps('orte', preview);
 
   const paramsSlug = params.slug.toLowerCase();
 

--- a/utils/getPageProps.ts
+++ b/utils/getPageProps.ts
@@ -200,7 +200,10 @@ const fields = [
   ),
 ];
 
-export const getPageProps = async (slug: string): Promise<PageProps> => {
+export const getPageProps = async (
+  slug: string,
+  isPreview?: boolean
+): Promise<PageProps> => {
   const directus = new Directus(process.env.DIRECTUS || '');
 
   try {
@@ -210,7 +213,7 @@ export const getPageProps = async (slug: string): Promise<PageProps> => {
     })) as FetchedPage;
 
     return {
-      page: updatePageStructure(_page),
+      page: updatePageStructure(_page, isPreview),
     };
   } catch (err) {
     console.log(err);
@@ -220,7 +223,10 @@ export const getPageProps = async (slug: string): Promise<PageProps> => {
   }
 };
 
-const updatePageStructure = (fetchedPage: FetchedPage): Page => {
+const updatePageStructure = (
+  fetchedPage: FetchedPage,
+  isPreview?: boolean
+): Page => {
   return {
     slug: fetchedPage.slug,
     title: fetchedPage.title,
@@ -235,7 +241,9 @@ const updatePageStructure = (fetchedPage: FetchedPage): Page => {
     sections: fetchedPage.sections
       .filter(
         s =>
-          s.item.status === 'published' || process.env.NEXT_PUBLIC_DEVELOPMENT
+          s.item.status === 'published' ||
+          (isPreview && s.item.status === 'draft') ||
+          process.env.NEXT_PUBLIC_DEVELOPMENT
       )
       .map(section => {
         return {
@@ -255,6 +263,7 @@ const updatePageStructure = (fetchedPage: FetchedPage): Page => {
             .filter(
               e =>
                 e.item.status === 'published' ||
+                (isPreview && e.item.status === 'draft') ||
                 process.env.NEXT_PUBLIC_DEVELOPMENT
             )
             .map((element, index) => {


### PR DESCRIPTION
There is a new preview mode. Pages are built directly server side so if you change content you don't need to wait for static generation. Preview page also shows draft content. 

You can view a preview page via /api/preview?token={token}&slug={slug}
You can view a page with draft content via /api/preview?token={token}&slug=modellversuch

Sending you the token elsewhere.
Ideally we would include this route as a preview route in our cms. Unfortunately directus, in comparison to contentful does not support this. But I don't think it's big deal. 