### PR TITLE
add styles for strong text, and lists

### DIFF
--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -275,8 +275,14 @@ p {
 .hamburg {
   font-family: 'Maru', Tahoma, Arial, Helvetica, sans-serif;
 
-  ul {
-    list-style-position: inside;
+  strong {
+    background: rgba($hh_orange, 0.25);
+  }
+
+  ul,
+  ol {
+    font-size: 1.25rem;
+    margin-left: 10px;
   }
 
   h1,


### PR DESCRIPTION
Nach dem Mergen muss direkt https://hamburg-testet-grundeinkommen.de/jobs so angepasst werden, dass ul- und li-Tags für die Listen genutzt werden.