### PR TITLE
Meta favicon fix

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -26,3 +26,4 @@ https://5gutegruende.hamburg/*                  https://hamburg-testet-grundeink
 https://5gutegruende.com/*                      https://hamburg-testet-grundeinkommen.de/:splat  301!
 https://www.5gutegruende.hamburg/*              https://hamburg-testet-grundeinkommen.de/:splat  301!
 https://www.5gutegruende.com/*                  https://hamburg-testet-grundeinkommen.de/:splat  301!
+/favicon.ico  /favicon-hamburg.ico   200!  Host=hamburg-testet-grundeinkommen.de


### PR DESCRIPTION
Ensure the correct favicon is served for the Hamburg site. Although the browser tab already shows the correct favicon, Google was indexing /favicon.ico, which pointed to the default icon instead of the project-specific one, favicon-hamburg.ico.
A Host= rule was added to _redirects to rewrite /favicon.ico to favicon-hamburg.ico for the hamburg site