### PR TITLE
Favicon fix

### DIFF
--- a/layout/index.tsx
+++ b/layout/index.tsx
@@ -178,14 +178,7 @@ export const Layout = ({
               content={metaImage}
             />
           </>
-
-          {IS_BERLIN_PROJECT ? (
-            <link key="favicon" rel="icon" href="/favicon-berlin.ico" />
-          ) : IS_HAMBURG_PROJECT ? (
-            <link key="favicon" rel="icon" href="/favicon-hamburg.ico" />
-          ) : (
-            <link key="favicon" rel="icon" href="/favicon.ico" />
-          )}
+          <link key="favicon" rel="icon" href="/favicon.ico" />
         </Head>
         <Header mainMenu={mainMenu} currentRoute={currentRoute} />
         {children}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "xbge-next",
   "private": true,
   "scripts": {
+    "prebuild": "sh ./scripts/copy-favicon.sh",
     "dev": "next dev",
     "build": "next build",
     "start": "node server.js",

--- a/public/_redirects
+++ b/public/_redirects
@@ -26,4 +26,3 @@ https://5gutegruende.hamburg/*                  https://hamburg-testet-grundeink
 https://5gutegruende.com/*                      https://hamburg-testet-grundeinkommen.de/:splat  301!
 https://www.5gutegruende.hamburg/*              https://hamburg-testet-grundeinkommen.de/:splat  301!
 https://www.5gutegruende.com/*                  https://hamburg-testet-grundeinkommen.de/:splat  301!
-/favicon.ico  /favicon-hamburg.ico   200!  Host=hamburg-testet-grundeinkommen.de

--- a/scripts/copy-favicon.sh
+++ b/scripts/copy-favicon.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+if [ "$NEXT_PUBLIC_PROJECT" = "Hamburg" ]; then
+  cp public/favicon-hamburg.ico public/favicon.ico
+elif [ "$NEXT_PUBLIC_PROJECT" = "Berlin" ]; then
+  cp public/favicon-berlin.ico public/favicon.ico
+fi


### PR DESCRIPTION
<img width="725" height="344" alt="Screenshot 2025-08-26 at 13 20 54" src="https://github.com/user-attachments/assets/cf0c21d1-8806-4cea-8f36-72b2cfd47fbc" />
The wrong favicon is showing in Google search results because there are multiple favicons for different sites (Berlin, Hamburg, Expedition) that are currently rendered conditionally using JavaScript. Google doesn’t execute React runtime code—it just looks for a static /favicon.ico file. To fix this, we now copy the correct favicon into favicon.ico during the build step so that Google sees the right icon for each site.